### PR TITLE
a fix to be specific to the class passed in when map is called, not just the property name

### DIFF
--- a/Adminomatic/AutoMapper/Mapper.php
+++ b/Adminomatic/AutoMapper/Mapper.php
@@ -105,16 +105,20 @@ namespace Adminomatic\AutoMapper {
 			foreach($destinationReflection->getProperties(\ReflectionProperty::IS_PUBLIC) as $destinationProperty) {
 				
 				$map = null;
-				if($this->TryGetMap($destinationProperty, $map)) {
-					$destination->{$destinationProperty->name} = $this->MapMapping($map, $destinationProperty, $source);
-					continue;
-				}
+                if($this->TryGetMap($destinationProperty, $map)) {
 
-				$srcProperty = null;
-				if(self::TryGetReflectionProperty($destinationProperty->name, $source, $srcProperty)) {
-					$destination->{$destinationProperty->name} = $this->MapProperty($destinationProperty, $srcProperty->getValue($source));
-					continue;
-				}
+                    if (! ($map->FromMember) || $map->FromMember->Class == $sourceType){
+                        $destination->{$destinationProperty->name} = $this->MapMapping($map, $destinationProperty, $source);
+                        continue;
+                    }
+                }else{
+
+                    $srcProperty = null;
+                    if(self::TryGetReflectionProperty($destinationProperty->name, $source, $srcProperty)) {
+                        $destination->{$destinationProperty->name} = $this->MapProperty($destinationProperty, $srcProperty->getValue($source));
+                        continue;
+                    }
+                }
 			}
 			return $destination;
 		}


### PR DESCRIPTION
$mapper->CreateMap('destination::Username','sourcetype1::name');
$mapper->CreateMap('destination::SomeThingElse','sourcetype2::someproperty');

$myDestinationObject = $mapper->Map(new CSRCompletion(), $sourceObject1);
$myDestinationObject = $mapper->Map($myDestinationObject, $sourceObject2);

where sourceObject1 and sourceObject2 are different types, if they happen to have a property name in common (in my case 'name', even though I have a map saying it should be set from sourcetype1, the property Username in my destination will get set by sourceType2.
